### PR TITLE
pass fill-opacity option to SVG for plot bands

### DIFF
--- a/highstock.src.js
+++ b/highstock.src.js
@@ -6082,6 +6082,9 @@ Highcharts.PlotLineOrBand.prototype = {
 			path = axis.getPlotBandPath(from, to, options);
 			if (color) {
 				attribs.fill = color;
+				if (options.opacity) {
+					attribs['fill-opacity'] = options.opacity;
+				}
 			}
 			if (options.borderWidth) {
 				attribs.stroke = options.borderColor;


### PR DESCRIPTION
This allows the user to specify fill-opacity as well as color for plot bands.

For example, this Fiddle will show the two plot bands at different fill opacity:  http://jsfiddle.net/BA2vg/

NOTE: Apologies if this is not the standard way to submit patches; let me know if you would prefer some other method.
