### PR TITLE
getYTDExtremes use globalOptions useUTC

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "highstock",
   "version": "v5.0.14",
-  "main": "highstock.js"
+  "main": "highstock.src.js"
 }

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "highstock",
   "version": "v5.0.14",
-  "main": "highstock.src.js"
+  "main": "highstock.js"
 }

--- a/highstock.src.js
+++ b/highstock.src.js
@@ -36814,6 +36814,7 @@
             clickButton: function(i, redraw) {
                 var rangeSelector = this,
                     chart = rangeSelector.chart,
+                    globalOptions = H.defaultOptions.global,
                     rangeOptions = rangeSelector.buttonOptions[i],
                     baseAxis = chart.xAxis[0],
                     unionExtremes = (chart.scroller && chart.scroller.getUnionExtremes()) || baseAxis || {},
@@ -36889,7 +36890,7 @@
                             });
                             redraw = false;
                         }
-                        ytdExtremes = rangeSelector.getYTDExtremes(dataMax, dataMin, useUTC);
+                        ytdExtremes = rangeSelector.getYTDExtremes(dataMax, dataMin, globalOptions.useUTC);
                         newMin = rangeMin = ytdExtremes.min;
                         newMax = ytdExtremes.max;
 
@@ -37025,6 +37026,7 @@
             updateButtonStates: function() {
                 var rangeSelector = this,
                     chart = this.chart,
+                    globalOptions = H.defaultOptions.global,
                     baseAxis = chart.xAxis[0],
                     actualRange = Math.round(baseAxis.max - baseAxis.min),
                     hasNoData = !baseAxis.hasVisibleSeries,
@@ -37032,7 +37034,7 @@
                     unionExtremes = (chart.scroller && chart.scroller.getUnionExtremes()) || baseAxis,
                     dataMin = unionExtremes.dataMin,
                     dataMax = unionExtremes.dataMax,
-                    ytdExtremes = rangeSelector.getYTDExtremes(dataMax, dataMin, useUTC),
+                    ytdExtremes = rangeSelector.getYTDExtremes(dataMax, dataMin, globalOptions.useUTC),
                     ytdMin = ytdExtremes.min,
                     ytdMax = ytdExtremes.max,
                     selected = rangeSelector.selected,


### PR DESCRIPTION
`rangeSelector.getYTDExtremes` call was not taking useUTC from `globalOptions`, instead, it was using the fixed useUTC value that was set to `TRUE` initially.

This issue exists in version 5 and 6 both. Please fix it for both version 5 and 6, (we are depending on version 5).

```javascript
var addEvent = H.addEvent,
            Axis = H.Axis,
            Chart = H.Chart,
            css = H.css,
            createElement = H.createElement,
            dateFormat = H.dateFormat,
            defaultOptions = H.defaultOptions,
            useUTC = defaultOptions.global.useUTC,
```
useUTC value here was picked at initialization, never updated again when user tries to use
```javascript
Highcharts.setOptions({
    global: {
        useUTC: false
    }
});
```